### PR TITLE
Adding Cake YAML Support for YAML Merge

### DIFF
--- a/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
+++ b/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
@@ -58,4 +58,7 @@
       <Name>Cake.Yaml</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
 </Project>

--- a/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
+++ b/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Test.cs" />
+    <Compile Include="TestMergeObject.cs" />
     <Compile Include="TestObject.cs" />
     <Compile Include="FakeContext.cs" />
     <Compile Include="FakeCakeArguments.cs" />
@@ -49,6 +50,7 @@
   <ItemGroup>
     <None Include="packages.config" />
     <None Include="test.yaml" />
+    <None Include="TestMerge.Yaml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Cake.Yaml\Cake.Yaml.csproj">

--- a/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj.user
+++ b/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj.user
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <ProjectView>ShowAllFiles</ProjectView>
+  </PropertyGroup>
+</Project>

--- a/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj.user
+++ b/Cake.Yaml.Tests/Cake.Yaml.Tests.csproj.user
@@ -3,4 +3,13 @@
   <PropertyGroup>
     <ProjectView>ShowAllFiles</ProjectView>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <StartAction>Project</StartAction>
+    <StartProgram>
+    </StartProgram>
+    <StartArguments>
+    </StartArguments>
+    <StartWorkingDirectory>
+    </StartWorkingDirectory>
+  </PropertyGroup>
 </Project>

--- a/Cake.Yaml.Tests/Test.cs
+++ b/Cake.Yaml.Tests/Test.cs
@@ -14,6 +14,9 @@ namespace Cake.Yaml.Tests
 
         string SERIALIZED_YAML = "";
 
+        const string SERIALIZED_YAML_MERGE_DATA = "default: &default\n Item1: item1\n Item2: item2\n\nmerged:\n <<: *default\n Item3: test item3\n\nnodefault:\n Item1: nodef-item1\n Item2: nodef-item2\n Item3: nodef-item3\n";
+
+
         [SetUp]
         public void Setup ()
         {
@@ -72,26 +75,35 @@ namespace Cake.Yaml.Tests
         }
 
         [Test]
+        public void DeserializeMergeFromString()
+        {
+            var testObjectDictionary = context.CakeContext.DeserializeYaml<Dictionary<string, TestMergeObject>>(SERIALIZED_YAML_MERGE_DATA);
+            AssertDictionaryMatchesTestMergeYaml(testObjectDictionary);
+        }
+
+        [Test]
         public void DeserializeMergeFromFile()
         {
             var file = new FilePath("testmerge.yaml");
 
             var testObjectDictionary = context.CakeContext.DeserializeYamlFromFile<Dictionary<string, TestMergeObject>>(file);
-         
-            Assert.IsNotNull(testObjectDictionary);
-            Assert.AreEqual(3, testObjectDictionary.Count);
-            Assert.AreEqual("item1", testObjectDictionary["default"].Item1);
-            Assert.AreEqual("item2", testObjectDictionary["default"].Item2);
+
+            AssertDictionaryMatchesTestMergeYaml(testObjectDictionary);
+        }
+        public void AssertDictionaryMatchesTestMergeYaml(Dictionary<string, TestMergeObject> testDictionary)
+        {
+            Assert.AreEqual(3, testDictionary.Count);
+            Assert.AreEqual("item1", testDictionary["default"].Item1);
+            Assert.AreEqual("item2", testDictionary["default"].Item2);
 
             // item1 and item 2 are inherited from &default
-            Assert.AreEqual("item1", testObjectDictionary["merged"].Item1);
-            Assert.AreEqual("item2", testObjectDictionary["merged"].Item2);
-            Assert.AreEqual("test item3", testObjectDictionary["merged"].Item3);
+            Assert.AreEqual("item1", testDictionary["merged"].Item1);
+            Assert.AreEqual("item2", testDictionary["merged"].Item2);
+            Assert.AreEqual("test item3", testDictionary["merged"].Item3);
 
-            Assert.AreEqual("nodef-item1", testObjectDictionary["nodefault"].Item1);
-            Assert.AreEqual("nodef-item2", testObjectDictionary["nodefault"].Item2);
-            Assert.AreEqual("nodef-item3", testObjectDictionary["nodefault"].Item3);
-          
+            Assert.AreEqual("nodef-item1", testDictionary["nodefault"].Item1);
+            Assert.AreEqual("nodef-item2", testDictionary["nodefault"].Item2);
+            Assert.AreEqual("nodef-item3", testDictionary["nodefault"].Item3);
         }
 
         [Test]

--- a/Cake.Yaml.Tests/Test.cs
+++ b/Cake.Yaml.Tests/Test.cs
@@ -1,6 +1,7 @@
 ﻿using NUnit.Framework;
 using System;
 using Cake.Core.IO;
+using System.Collections.Generic;
 
 namespace Cake.Yaml.Tests
 {
@@ -39,6 +40,12 @@ namespace Cake.Yaml.Tests
         }
 
         [Test]
+        public void DeserializeWithMergeToFile()
+        {
+
+        }
+
+        [Test]
         public void SerializeToFile ()
         {
             var obj = new TestObject ();
@@ -62,6 +69,29 @@ namespace Cake.Yaml.Tests
 
             Assert.IsNotNull (testObject);
             Assert.AreEqual ("Testing", testObject.Name);
+        }
+
+        [Test]
+        public void DeserializeMergeFromFile()
+        {
+            var file = new FilePath("testmerge.yaml");
+
+            var testObjectDictionary = context.CakeContext.DeserializeYamlFromFile<Dictionary<string, TestMergeObject>>(file);
+         
+            Assert.IsNotNull(testObjectDictionary);
+            Assert.AreEqual(3, testObjectDictionary.Count);
+            Assert.AreEqual("item1", testObjectDictionary["default"].Item1);
+            Assert.AreEqual("item2", testObjectDictionary["default"].Item2);
+
+            // item1 and item 2 are inherited from &default
+            Assert.AreEqual("item1", testObjectDictionary["merged"].Item1);
+            Assert.AreEqual("item2", testObjectDictionary["merged"].Item2);
+            Assert.AreEqual("test item3", testObjectDictionary["merged"].Item3);
+
+            Assert.AreEqual("nodef-item1", testObjectDictionary["nodefault"].Item1);
+            Assert.AreEqual("nodef-item2", testObjectDictionary["nodefault"].Item2);
+            Assert.AreEqual("nodef-item3", testObjectDictionary["nodefault"].Item3);
+          
         }
 
         [Test]

--- a/Cake.Yaml.Tests/TestMerge.Yaml
+++ b/Cake.Yaml.Tests/TestMerge.Yaml
@@ -1,0 +1,12 @@
+﻿default: &default
+  Item1: item1
+  Item2: item2
+
+merged:
+  <<: *default
+  Item3: test item3
+
+nodefault:
+  Item1: nodef-item1
+  Item2: nodef-item2
+  Item3: nodef-item3

--- a/Cake.Yaml.Tests/TestMergeObject.cs
+++ b/Cake.Yaml.Tests/TestMergeObject.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cake.Yaml.Tests
+{
+    class TestMergeObject
+    {
+        public string Item1 { get; set; }
+        public string Item2 { get; set; }
+        public string Item3 { get; set; }
+    }
+}

--- a/Cake.Yaml.Tests/TestMergeObject.cs
+++ b/Cake.Yaml.Tests/TestMergeObject.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Cake.Yaml.Tests
 {
-    class TestMergeObject
+    public class TestMergeObject
     {
         public string Item1 { get; set; }
         public string Item2 { get; set; }

--- a/Cake.Yaml/YamlAliases.cs
+++ b/Cake.Yaml/YamlAliases.cs
@@ -4,6 +4,7 @@ using Cake.Core.IO;
 using Cake.Core;
 using System.IO;
 using System.Text;
+using YamlDotNet.Core;
 
 namespace Cake.Yaml
 {
@@ -22,13 +23,17 @@ namespace Cake.Yaml
         /// <typeparam name="T">The type to deserialize to.</typeparam>
         [CakeMethodAlias]
         //[CakeNamespaceImport("YamlDotNet")]
-        public static T DeserializeYamlFromFile<T> (this ICakeContext context, FilePath filename)
+        public static T DeserializeYamlFromFile<T>(this ICakeContext context, FilePath filename)
         {
             T result = default(T);
 
-            var d = new YamlDotNet.Serialization.Deserializer ();
-            using (var tr = File.OpenText (filename.MakeAbsolute (context.Environment).FullPath))
-                result = d.Deserialize<T> (tr);
+            var d = new YamlDotNet.Serialization.Deserializer();
+
+            using (var tr = File.OpenText(filename.MakeAbsolute(context.Environment).FullPath))
+            {
+                var reader = new EventReader(new MergingParser(new Parser(tr)));
+                result = d.Deserialize<T>(reader);
+            }
 
             return result;
         }

--- a/Cake.Yaml/YamlAliases.cs
+++ b/Cake.Yaml/YamlAliases.cs
@@ -52,9 +52,11 @@ namespace Cake.Yaml
             T result = default(T);
 
             var d = new YamlDotNet.Serialization.Deserializer ();
-            using (var tr = new StringReader (yaml))
-                result = d.Deserialize<T> (tr);
-
+            using (var tr = new StringReader(yaml))
+            {
+                var reader = new EventReader(new MergingParser(new Parser(tr)));
+                result = d.Deserialize<T>(reader);
+            }
             return result;
         }
 


### PR DESCRIPTION
I needed the ability to parse a YAML file with a merge key.  The YAML DotNet framework supports it (see this StackOverflow [article](http://stackoverflow.com/questions/18894610/does-c-sharp-yamldotnet-library-support-the-merge-key)), but the parser used before will not support it.

To do this, you need to use the MergingParser in place of the StringReader.

```
 using (var tr = new StringReader(yaml))
        {
            var reader = new EventReader(new MergingParser(new Parser(tr)));
            result = d.Deserialize<T>(reader);
        }
```

I added tests to make sure this functionality works and is backward compatible.
